### PR TITLE
Fix code smell - duplicated variable name in currencyService

### DIFF
--- a/src/components/exchangeRateHistory/exchangeRateHistory.module.scss
+++ b/src/components/exchangeRateHistory/exchangeRateHistory.module.scss
@@ -8,44 +8,44 @@
 .periodButtons {
   display: flex;
   justify-content: center;
-}
 
-.monthButton,
-.monthButton:hover {
-  margin: 10px;
-  background-color: $cc-purple;
-  border-color: $cc-purple;
+  .monthButton,
+  .monthButton:hover {
+    margin: 10px;
+    background-color: $cc-purple;
+    border-color: $cc-purple;
 
-  &.active {
-    background-color: $cc-purple-dark;
+    &.active {
+      background-color: $cc-purple-dark;
+    }
+  }
+
+  @media screen and (max-width: 414px) {
+    .monthButton {
+      height: 30px;
+      font-size: 0.8rem;
+    }
+  }
+
+  @media screen and (max-width: 365px) {
+    .monthButton {
+      margin: 10px 5px;
+
+      :global {
+        .anticon {
+          display: none;
+        }
+      }
+
+      span:last-of-type {
+        margin: 0;
+      }
+    }
   }
 }
 
 @media screen and (min-width: 414px) {
   .backToDashboard {
     margin-top: 15px;
-  }
-}
-
-@media screen and (max-width: 414px) {
-  .monthButton {
-    height: 30px;
-    font-size: 0.8rem;
-  }
-}
-
-@media screen and (max-width: 365px) {
-  .monthButton {
-    margin: 10px 5px;
-
-    :global {
-      .anticon {
-        display: none;
-      }
-    }
-
-    span:nth-child(2) {
-      margin: 0;
-    }
   }
 }

--- a/src/components/exchangeRateHistory/exchangeRateHistory.tsx
+++ b/src/components/exchangeRateHistory/exchangeRateHistory.tsx
@@ -46,7 +46,7 @@ export const ExchangeRateHistoryComponent: React.FC<Props> = ({ selectedCurrenci
             setPeriod(value)
           }}
         >
-          {t(key)}{' '}
+          {t(key)}
         </Button>
       )
     })

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,6 +1,5 @@
-import { ApiRate } from 'components/dashboard/dashboard'
 import { polishCurrencyObject } from 'constants/polishCurrencyObject'
-import { CurrencyResponse } from 'services/currencyService'
+import { CurrencyObject, CurrencyResponse } from 'services/currencyService'
 
 import { sort } from './array'
 
@@ -15,7 +14,7 @@ export function addNewPropertyToTableObjectElement(
   })
 }
 
-export function returnPreparedCurrencyObject(data: CurrencyResponse): { rates: ApiRate[]; date: string } {
+export function returnPreparedCurrencyObject(data: CurrencyResponse): CurrencyObject {
   data.currencyTableA.forEach((tableAElement) => {
     addNewPropertyToTableObjectElement(tableAElement.rates, 'table', tableAElement.table)
   })


### PR DESCRIPTION
Add HistoricalData and CurrencyObject types;
Remove uneeded forkJoin for a single request;
Rename duplicated variable name;
Increase history period buttons specificity due to overwriting them by Ant design in develop mode;