### PR TITLE
Reduce amount of dashboard currencies requests

### DIFF
--- a/src/components/dashboard/dashboard.container.tsx
+++ b/src/components/dashboard/dashboard.container.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import { useCurrenciesFetch } from '../../services/currencyService'
 
@@ -10,20 +10,7 @@ type Response = {
 }
 
 export const DashboardContainer: React.FC = () => {
-  const [apiRates, setApiRates] = useState<ApiRate[]>([])
-  const [date, setCurrentDate] = useState('')
+  const { rates, date } = useCurrenciesFetch()
 
-  const [dataReady, setDataReady] = useState(false)
-
-  const resource = useCurrenciesFetch()
-
-  useEffect(() => {
-    resource.subscribe((response) => {
-      setApiRates(response.rates)
-      setCurrentDate(response.date)
-      setDataReady(true)
-    })
-  }, [])
-
-  return <Dashboard rates={apiRates} date={date} dataReady={dataReady} />
+  return <Dashboard rates={rates} date={date} dataReady={!!rates.length} />
 }

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,6 @@
+import { from, Observable } from 'rxjs'
+
+//eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const request$ = (url: string): Observable<any> => {
+  return from(fetch(url).then((data) => data.json()))
+}


### PR DESCRIPTION
Refactor useCurrenciesFetch custom hook. 

Now there's only one request when user go to dashboard, instead of 3. 